### PR TITLE
Improve robustness during lengthly view builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If the design document is already present and is identical to the one in the fil
 * copy old design document to _OLD
 * import new design document to _NEW
 * trigger the view to make sure it builds
-* poll _active_tasks to see if it has finished building
+* poll the view to see if it has finished building
 * copy _NEW to the real design document name
 * delete _NEW 
 * delete _OLD

--- a/app.js
+++ b/app.js
@@ -10,12 +10,21 @@ var fs = require('fs'),
 var COUCH_URL = null;
 if (typeof process.env.COUCH_URL == "undefined") {
   console.log("Please use environment variable COUCH_URL to indicate URL of your CouchDB/Cloudant");
-  console.log("  e.g. export COUCH_URL=http://127.0.0.1:5984")
+  console.log("  e.g. export COUCH_URL=http://127.0.0.1:5984");
   process.exit(1);
 } else {
   COUCH_URL = process.env.COUCH_URL;
 }
-var nano = require('nano')( { url: COUCH_URL, requestDefaults: { timeout: 10000}});
+var nano = require('nano')( {
+  url: COUCH_URL,
+  requestDefaults: {
+    timeout: 10000,
+    headers: {
+      'User-Agent': 'couchmigrate',
+      'x-cloudant-io-priority': 'low'
+    }
+  }
+});
 var db = nano.db.use(argv.db);
 
 var debug = function(err, data) {
@@ -38,7 +47,7 @@ var copydoc = function(from_id, to_id, cb) {
           from_doc = data;
         }
         callback(err, data);
-      })
+      });
     },
     
     // fetch the document we are copying to (if it is there)
@@ -50,7 +59,7 @@ var copydoc = function(from_id, to_id, cb) {
           to_doc = data;
         }
         callback(null, data);
-      })
+      });
     },
     
     // overwrite the destination
@@ -60,12 +69,12 @@ var copydoc = function(from_id, to_id, cb) {
       if (to_doc) {
         from_doc._rev = to_doc._rev;
       } else { 
-        delete from_doc._rev
+        delete from_doc._rev;
       }
       console.log("## copydoc - contents",from_doc);
       db.insert(from_doc, function(err, data) {
         debug(err, data);
-        callback(null, data);
+        callback(err, data);
       });
     }
   ], cb);
@@ -82,20 +91,20 @@ var writedoc = function(obj, docid, cb) {
           preexistingdoc = data;
         }
         callback(null, data);
-      })
+      });
     },
     function(callback) {
       obj._id = docid;
       if (preexistingdoc) {
-        obj._rev = preexistingdoc._rev
+        obj._rev = preexistingdoc._rev;
       }
       console.log("## writedoc - Writing doc", obj);
       db.insert(obj, function(err, data) {
         debug(err, data);
-        callback(null, data);
+        callback(err, data);
       });
     }
-  ], cb)
+  ], cb);
 };
 
 var deletedoc = function(docid, cb) {
@@ -109,7 +118,7 @@ var deletedoc = function(docid, cb) {
     console.log("## deletedoc - Deleting ", docid, data._rev);
     db.destroy( docid, data._rev, function(err, d) {
       debug(err,d);
-      cb(null, null); 
+      cb(null, null);
     });
   });
 
@@ -134,6 +143,7 @@ fs.readFile(dd_filename, {encoding: "utf8"}, function(err, data) {
     console.log("FAILED to parse file contents as JSON - cannot continue");
     process.exit(1);
   }
+
   var dd_name = dd._id;
   var original_dd = null;
   var old_dd = null;
@@ -145,14 +155,14 @@ fs.readFile(dd_filename, {encoding: "utf8"}, function(err, data) {
   async.series( [
     // check that the database exists
     function(callback) {
-      console.log("## check db exists");     
+      console.log("## check db exists");
       // if it doesn't we'll get an 'err' and the async process will stop
       nano.db.get(argv.db, function(err, data) {
         debug(err,data);
         callback(err,data);
       });
     },
-    
+
     // check that the existing view isn't the same as the incoming view
     function(callback) {
       db.get(dd_name, function(err, data) {
@@ -172,7 +182,7 @@ fs.readFile(dd_filename, {encoding: "utf8"}, function(err, data) {
         } else {
           callback(null,null);
         }
-      })
+      });
     },
        
     // copy original design document to _OLD
@@ -189,52 +199,58 @@ fs.readFile(dd_filename, {encoding: "utf8"}, function(err, data) {
       writedoc(dd, dd_new_name, callback)
     },
     
-    // trigger a new index.build
+    // wait for the view build to complete, by polling
     function(callback) {
-      var name = dd._id.replace(/_design\//,"");
-      var v = Object.keys(dd.views)[0];
-      console.log("## trigger a new index.build for", name, "/", v);
-      
-      // wait 3 seconds before querying the view
-      setTimeout(function() {
-        db.view(name, v, { limit:1 }, function(err, data) {
-          debug(err, data);
-          // on a long view-build this request will timeout and return an 'err', which we can ignore
-          callback(null, null);
-        });
-      }, 3000);
-      
-    },
-    
-    // wait for the view build to complete, by polling _active_tasks
-    function(callback) {
-      console.log("## wait for the view build to complete, by polling _active_tasks");
-      
-      var numTasks = 1;
+      var hasData = false;
+
       async.doWhilst(
 
           function (callback) {
-            setTimeout(function() {
-              nano.request({ path:"_active_tasks"}, function(err, data) {
-                debug(err,data);
-                numTasks = 0;
-                for(var i in data) {
-                  if(data[i].type != "view_compaction" && data[i].type != "replication") {
-                    numTasks++;
-                  }
-                }
-                callback(null, null);
-              });
-            }, 5000);
+            var name = dd._id.replace(/_design\//,"");
+            var v = Object.keys(dd.views)[0];
+            console.log("## query ", name, "/", v, "to validate freshness.");
 
-            
+            setTimeout(function() {
+
+              db.view(name, v, { limit:1 }, function(err, data) {
+                debug(err, data);
+
+                // on a long view-build this request will timeout and return an 'err'.
+                // we should retry until this returns
+                hasData = !err && !!data;
+
+                if (err) {
+                  // get progress from active tasks
+                  nano.request({ path:"_active_tasks"}, function(err, data) {
+                    debug(err,data);
+                    var progress = 0;
+                    var shards = 0;
+                    for(var i in data) {
+                      var task = data[i];
+
+                      if (task.type === "indexer" && task.design_document === dd_new_name) {
+                        shards++;
+                        progress = progress + parseInt(task.progress, 10);
+                      }
+                    }
+
+                    var overallProgress = Math.floor(progress / shards);
+                    console.log('## indexing progress:', overallProgress, "%");
+                    callback(null, null);
+                  });
+                }
+                else {
+                  callback(null, null);
+                }
+              });
+            }, 3000);
+
           },
-          function () { return numTasks>0 },
+          function () { return !hasData; },
           function (err) {
-             callback(null, null)
+             callback(err, null);
           }
       );
-    
     },
     
     // copy _NEW to live
@@ -259,6 +275,9 @@ fs.readFile(dd_filename, {encoding: "utf8"}, function(err, data) {
     }
     
   ], function(err, data) {
+    if (err) {
+      console.log(err);
+    }
     console.log("FINISHED!!!");
   });
 


### PR DESCRIPTION
Rather than polling active tasks to determin whether an index build
is complete, query the view itself. If a view returns within the
timeout, it must be fresh. If not, query active tasks to calculate
the progress.

Error handling is also improved so that the tool exits if the target
document is invalid or the view freshness can't be verified.