### PR TITLE
Added ability to pass CouchDB URL using command-line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,17 @@ or
 
     export COUCH_URL=https://myusername:mypassword@myhost.cloudant.com
 
+or
+
+    use --url command-line argument to pass the instance URL
+
 Then run `couchmigrate`:
 
-    couchmigrate --dd dd.json --db mydatabase
+    couchmigrate --dd dd.json --db mydatabase [--url http://127.0.0.1:5984]
 
 * dd - the path to the file containing the design documnet 
 * db - the name of the database
+* url - the URL of the CouchDB instance
 
 (if the file extension of `dd` is '.json', it is expected to be a JSON document, if it ends in '.js' it is expected to be a JavaScript file that can be `require`d in)
 

--- a/app.js
+++ b/app.js
@@ -2,18 +2,18 @@ var fs = require('fs'),
   async = require('async'),
   argv = require('yargs')
    .usage("CouchDB design document migration")
-   .usage('Usage: $0 --dd <design document filename> --db <name of database>')
+   .usage('Usage: $0 --dd <design document filename> --db <name of database> [--url <url of CouchDB/Cloudant>]')
    .demand(['dd','db'])
    .argv;
   
 // get COUCH_URL from the environment
 var COUCH_URL = null;
-if (typeof process.env.COUCH_URL === 'undefined') {
-  console.log("Please use environment variable COUCH_URL to indicate URL of your CouchDB/Cloudant");
+if (typeof process.env.COUCH_URL === 'undefined' && typeof argv.url === 'undefined') {
+  console.log("Please use environment variable COUCH_URL or --url argument to indicate URL of your CouchDB/Cloudant");
   console.log("  e.g. export COUCH_URL=http://127.0.0.1:5984");
   process.exit(1);
 } else {
-  COUCH_URL = process.env.COUCH_URL;
+  COUCH_URL = argv.url || process.env.COUCH_URL;
 }
 var nano = require('nano')( {
   url: COUCH_URL,


### PR DESCRIPTION
Having to set the COUCH_URL environment is not practicle when working with multiple CouchDB instances (e.g. development vs. production). Also, setting or updating the variable requires system restart, at least in Windows. So I added an ability to pass the URL using --url command-line argument.